### PR TITLE
Add a custom lexer for #lang colon-kw for DrRacket syntax highlighting

### DIFF
--- a/colon-kw/lang/lexer.rkt
+++ b/colon-kw/lang/lexer.rkt
@@ -1,0 +1,32 @@
+#lang racket/base
+
+(provide make-colon-kw-lexer)
+
+(require racket/match)
+
+(define (make-colon-kw-lexer orig-lexer)
+  (if (procedure-arity-includes? orig-lexer 3)
+      (λ (in offset mode)
+        (match (peek-char in)
+          [#\: (match-let*-values ([(_ _ initial-loc) (begin0 (port-next-location in) (read-char in))]
+                                   [(text orig-type _ orig-start orig-end backup new-mode) (orig-lexer in offset mode)]
+                                   [(type) (if (eq? orig-type 'symbol) 'hash-colon-keyword 'error)]
+                                   [(start end) (if orig-start
+                                                    (values (sub1 orig-start) orig-end)
+                                                    (values initial-loc initial-loc))])
+                 (values (prepend-colon text) type #f start end backup new-mode))]
+          [_   (orig-lexer in offset mode)]))
+      (λ (in)
+        (match (peek-char in)
+          [#\: (match-let*-values ([(_ _ initial-loc) (begin0 (port-next-location in) (read-char in))]
+                                   [(text orig-type _ orig-start orig-end) (orig-lexer in)]
+                                   [(type) (if (eq? orig-type 'symbol) 'hash-colon-keyword 'error)]
+                                   [(start end) (if orig-start
+                                                    (values (sub1 orig-start) orig-end)
+                                                    (values initial-loc initial-loc))])
+                 (values (prepend-colon text) type #f start end))]
+          [_   (orig-lexer in)]))))
+
+(define (prepend-colon str/eof)
+  (if (eof-object? str/eof) ":"
+      (string-append ":" str/eof)))

--- a/colon-kw/lang/reader.rkt
+++ b/colon-kw/lang/reader.rkt
@@ -5,7 +5,8 @@
                      [colon-kw-get-info get-info]))
 
 (require (only-in syntax/module-reader make-meta-reader)
-         "../reader.rkt")
+         "../reader.rkt"
+         "lexer.rkt")
 
 (define (wrap-reader reader)
   (define (rd . args)
@@ -32,5 +33,9 @@
      (lambda (key defval)
        (define (fallback) (if proc (proc key defval) defval))
        (case key
+         [(color-lexer)
+          (make-colon-kw-lexer
+           (or (fallback)
+               (dynamic-require 'syntax-color/racket-lexer 'racket-lexer)))]
          [else (fallback)])))))
 


### PR DESCRIPTION
This is a fix for #2 that works by just deferring to the existing Racket lexer to keep things simple. I took a brief look at 45036f1652bfdc4a1a6beccf4e5062530b220baf, which this is somewhat based on, but I admit I honestly don’t understand some of what you were doing, so I mostly wrote this from scratch.
